### PR TITLE
Add a basic homepage for the tool at tools.wmflabs.org

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -20,7 +20,7 @@ get '/prompter/?' do
   mediawiki_site = params[:mediawiki_site]
   page_title = params[:page_title]
 
-  halt "Please provide ?mediawiki_site and ?page_title GET parameters" unless mediawiki_site && page_title
+  return erb(:homepage) unless mediawiki_site && page_title
 
   unless mediawiki_site =~ /^(www\.)?wikidata.org|[a-z]{2}.wikipedia.org$/
     halt "Disallowed mediawiki_site"

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+  </head>
+  <body>
+
+    <div class="container mt-3">
+      <h1>Prompter</h1>
+
+      <p>The prompter tool allows you to simply compare data
+        from Wikidata (found from a SPARQL query) with an
+        external CSV file.</p>
+
+      <p>In order to use the prompter, you just add the
+        <a href="https://www.wikidata.org/wiki/Template:Compare_Wikidata_with_CSV"><tt>{{Compare Wikidata with CSV}}</tt></a>
+        template to a page.</p>
+
+      <p>The source code for the prompter tool can be found in
+        these two repositories:</p>
+
+      <ul>
+        <li><a href="https://github.com/everypolitician/prompter">everypolitician/prompter</a>: the HTTP interface to the tool</li>
+        <li><a href="https://github.com/everypolitician/compare_with_wikidata">everypolitician/compare_with_wikidata</a>: the underlying library that compares the data</li>
+      </ul>
+
+      <p>This tool is being developed as part of the
+        <a href="https://meta.wikimedia.org/wiki/Grants:Project/mySociety/EveryPolitician">Wikimedia
+        / mySociety / EveryPolitician</a> grant.</p>
+    </div>
+
+    <!-- jQuery first, then Popper, then Bootstrap JS. -->
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.2.1/jquery.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a basic homepage for https://tools.wmflabs.org/prompter/

Desktop view:

![homepage-bigger](https://user-images.githubusercontent.com/7907/29528079-9d0dcfce-8692-11e7-8726-fa4143f02503.png)

Mobile view:

![prompter-mobile](https://user-images.githubusercontent.com/7907/29528020-6964f60c-8692-11e7-9ea0-88e469cf24d4.png)

Fixes #4