### PR TITLE
Add script/cronjob for updating prompts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'compare_with_wikidata', github: 'everypolitician/compare_with_wikidata', branch: 'master'
+gem 'mediawiki_api'
 gem 'puma'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ PLATFORMS
 
 DEPENDENCIES
   compare_with_wikidata!
+  mediawiki_api
   puma
   sinatra
 

--- a/app.rb
+++ b/app.rb
@@ -1,13 +1,5 @@
 require 'bundler/setup'
-require 'yaml'
-
-begin
-  secrets = YAML.load_file('secrets.yml')
-  ENV['WIKI_USERNAME'] = secrets['WIKI_USERNAME']
-  ENV['WIKI_PASSWORD'] = secrets['WIKI_PASSWORD']
-rescue Errno::ENOENT
-  abort "Please run 'cp secrets.yml-example secrets.yml' and then fill out secrets.yml"
-end
+require_relative 'lib/load_environment_from_yaml'
 
 require 'compare_with_wikidata'
 require 'sinatra'

--- a/lib/load_environment_from_yaml.rb
+++ b/lib/load_environment_from_yaml.rb
@@ -1,0 +1,9 @@
+require 'yaml'
+
+begin
+  secrets = YAML.load_file(File.expand_path(__dir__ + '/../secrets.yml'))
+  ENV['WIKI_USERNAME'] = secrets['WIKI_USERNAME']
+  ENV['WIKI_PASSWORD'] = secrets['WIKI_PASSWORD']
+rescue Errno::ENOENT
+  abort "Please run 'cp secrets.yml-example secrets.yml' and then fill out secrets.yml"
+end

--- a/script/cronjob
+++ b/script/cronjob
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+require 'bundler/setup'
+require_relative '../lib/load_environment_from_yaml'
+
+require 'compare_with_wikidata'
+require 'mediawiki_api'
+
+WIKI_SITE = 'www.wikidata.org'
+WIKI_USERNAME = ENV['WIKI_USERNAME']
+WIKI_PASSWORD = ENV['WIKI_PASSWORD']
+WIKI_TEMPLATE_NAME = 'Template:Compare Wikidata with CSV'.freeze
+
+client = MediawikiApi::Client.new("https://#{WIKI_SITE}/w/api.php")
+result = client.log_in(WIKI_USERNAME, WIKI_PASSWORD)
+abort "MediawikiApi::Client#log_in failed: #{result}" unless result['result'] == 'Success'
+
+result = client.action(:query, list: 'embeddedin', eititle: WIKI_TEMPLATE_NAME, eilimit: 500)
+abort "Failed to find pages embedding #{WIKI_TEMPLATE_NAME}" unless result.success?
+
+result.data['embeddedin'].map { |ei| ei['title'] }.each do |title|
+  puts "  Updating #{title}"
+
+  diff_output_generator = CompareWithWikidata::DiffOutputGenerator.new(
+    mediawiki_site: WIKI_SITE,
+    page_title: title
+  )
+
+  begin
+    diff_output_generator.run!
+  rescue => e
+    warn "Error updating #{title}: #{e.message}"
+  end
+end


### PR DESCRIPTION
This adds a script which when installed as a cronjob will update all prompts on a regular basis. It uses the [Embeddedin](https://www.mediawiki.org/wiki/API:Embeddedin) API to find a list of pages that the `{{Compare Wikidata with CSV}}` template is embedded in, then runs each one of those through the prompt updater.

## Todo before merging

- [ ] [Read environment variables from `secrets.yml`](https://github.com/everypolitician/prompter/blob/c6a1eb53c0498b53f07c9df60dbeaaef053013ff/app.rb#L2-L10).
- [ ] Uncomment the `diff_output_generator.run!` line.

Part of https://github.com/everypolitician/compare_with_wikidata/issues/34